### PR TITLE
playframework-2.1.1

### DIFF
--- a/module/pom.xml
+++ b/module/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.atmosphere</groupId>
         <artifactId>play-project</artifactId>
@@ -19,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>play</groupId>
-            <artifactId>play_2.9.1</artifactId>
+            <artifactId>play_2.10</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/module/src/main/java/org/atmosphere/play/PlayAsyncIOWriter.java
+++ b/module/src/main/java/org/atmosphere/play/PlayAsyncIOWriter.java
@@ -15,14 +15,7 @@
  */
 package org.atmosphere.play;
 
-import org.atmosphere.cpr.AsyncIOWriter;
-import org.atmosphere.cpr.AsynchronousProcessor;
-import org.atmosphere.cpr.AtmosphereConfig;
-import org.atmosphere.cpr.AtmosphereInterceptorWriter;
-import org.atmosphere.cpr.AtmosphereRequest;
-import org.atmosphere.cpr.AtmosphereResponse;
-import org.atmosphere.cpr.FrameworkConfig;
-import org.atmosphere.cpr.HeaderConfig;
+import org.atmosphere.cpr.*;
 import org.atmosphere.util.ByteArrayAsyncWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,19 +31,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PlayAsyncIOWriter extends AtmosphereInterceptorWriter implements PlayInternal<Results.Chunks> {
     private static final Logger logger = LoggerFactory.getLogger(PlayAsyncIOWriter.class);
-
     private final AtomicInteger pendingWrite = new AtomicInteger();
     private final AtomicBoolean asyncClose = new AtomicBoolean(false);
-    private boolean byteWritten = false;
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
-    private long lastWrite = 0;
     private final ByteArrayAsyncWriter buffer = new ByteArrayAsyncWriter();
     protected Results.Chunks<String> chunks;
     protected Results.Chunks.Out<String> out;
+    private boolean byteWritten = false;
+    private long lastWrite = 0;
     private boolean resumeOnBroadcast;
 
     public PlayAsyncIOWriter(final Http.Request request, final Http.Response response) {
-        chunks = new Results.Chunks<String>(JavaResults.writeString(Codec.utf_8()), JavaResults.contentTypeOfString((Codec.utf_8()))) {
+        chunks = new Results.Chunks<String>(JavaResults.writeString(Codec.utf_8())) {
             @Override
             public void onReady(Results.Chunks.Out<String> oout) {
                 out = oout;
@@ -88,7 +80,6 @@ public class PlayAsyncIOWriter extends AtmosphereInterceptorWriter implements Pl
             response.setContentType("text/event-stream");
         }
     }
-
 
     public Results.Chunks internal() {
         return chunks;
@@ -165,9 +156,9 @@ public class PlayAsyncIOWriter extends AtmosphereInterceptorWriter implements Pl
         return this;
     }
 
-    private void _close(AtmosphereRequest request){
+    private void _close(AtmosphereRequest request) {
         final AsynchronousProcessor.AsynchronousProcessorHook hook = (AsynchronousProcessor.AsynchronousProcessorHook)
-               request.getAttribute(FrameworkConfig.ASYNCHRONOUS_HOOK);
+                request.getAttribute(FrameworkConfig.ASYNCHRONOUS_HOOK);
         if (hook != null) {
             hook.closed();
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -46,14 +47,14 @@
         <dependencies>
             <dependency>
                 <groupId>play</groupId>
-                <artifactId>play_2.9.1</artifactId>
-                <version>2.0.4</version>
+                <artifactId>play_2.10</artifactId>
+                <version>2.1.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.atmosphere</groupId>
                 <artifactId>atmosphere-play</artifactId>
-                <version>${pom.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.atmosphere</groupId>
@@ -77,17 +78,17 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.6.4</version>
+                <version>1.7.5</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.13</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.13</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -243,7 +244,7 @@
                         <link>http://docs.oracle.com/javaee/6/docs/api/</link>
                         <link>http://docs.oracle.com/javase/6/docs/api/</link>
                     </links>
-                    <excludePackageNames />
+                    <excludePackageNames/>
                 </configuration>
             </plugin>
             <plugin>
@@ -299,7 +300,7 @@
         <surefire.redirectTestOutputToFile>false</surefire.redirectTestOutputToFile>
         <source.property>1.6</source.property>
         <target.property>1.6</target.property>
-        <atmosphere.version>1.1.0.RC1</atmosphere.version>
+        <atmosphere.version>1.1.0.RC2</atmosphere.version>
     </properties>
 </project>
 

--- a/samples/chat/pom.xml
+++ b/samples/chat/pom.xml
@@ -18,19 +18,15 @@
 		</dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>de.akquinet.innovation.play2</groupId>
+				<groupId>org.nanoko.playframework</groupId>
 				<artifactId>play2-maven-plugin</artifactId>
-				<version>1.2.1</version>
+				<version>1.2.2</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/samples/chat/project/Build.scala
+++ b/samples/chat/project/Build.scala
@@ -1,23 +1,25 @@
 import sbt._
 import Keys._
-import PlayProject._
+import play.Project._
+
 
 object ApplicationBuild extends Build {
 
-    def fromEnv(name: String) = System.getenv(name) match {
-        case null => None
-        case value => Some(value)
-    }
+  def fromEnv(name: String) = System.getenv(name) match {
+    case null => None
+    case value => Some(value)
+  }
 
-    val appName         = fromEnv("project.artifactId").getOrElse("atmosphere-play-chat")
-    val appVersion      = fromEnv("project.version").getOrElse("1.0.0-SNAPSHOT")
+  val appName = fromEnv("project.artifactId").getOrElse("atmosphere-play-chat")
+  val appVersion = fromEnv("project.version").getOrElse("1.0.0-SNAPSHOT")
 
-    val appDependencies = Seq(
-        // Dependencies are managed by maven
-        // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
-        // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
-    )
+  val appDependencies = Seq(
+    javaCore
+    // Dependencies are managed by maven
+    // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
+    // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
+  )
 
-    val main = PlayProject(appName, appVersion, appDependencies, mainLang = JAVA).settings()
+  val main = play.Project(appName, appVersion, appDependencies).settings()
 
 }

--- a/samples/chat/project/build.properties
+++ b/samples/chat/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.2

--- a/samples/chat/project/plugins.sbt
+++ b/samples/chat/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.0.4")
+addSbtPlugin("play" % "sbt-plugin" % "2.1.1")

--- a/samples/jersey/pom.xml
+++ b/samples/jersey/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.atmosphere</groupId>
@@ -23,10 +24,6 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
@@ -38,9 +35,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>de.akquinet.innovation.play2</groupId>
+                <groupId>org.nanoko.playframework</groupId>
                 <artifactId>play2-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.2.2</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/samples/jersey/project/Build.scala
+++ b/samples/jersey/project/Build.scala
@@ -1,23 +1,24 @@
 import sbt._
 import Keys._
-import PlayProject._
+import play.Project._
 
 object ApplicationBuild extends Build {
 
-    def fromEnv(name: String) = System.getenv(name) match {
-        case null => None
-        case value => Some(value)
-    }
+  def fromEnv(name: String) = System.getenv(name) match {
+    case null => None
+    case value => Some(value)
+  }
 
-    val appName         = fromEnv("project.artifactId").getOrElse("atmosphere-play-chat")
-    val appVersion      = fromEnv("project.version").getOrElse("1.0.0-SNAPSHOT")
+  val appName = fromEnv("project.artifactId").getOrElse("atmosphere-play-chat")
+  val appVersion = fromEnv("project.version").getOrElse("1.0.0-SNAPSHOT")
 
-    val appDependencies = Seq(
-        // Dependencies are managed by maven
-        // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
-        // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
-    )
+  val appDependencies = Seq(
+    javaCore
+    // Dependencies are managed by maven
+    // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
+    // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
+  )
 
-    val main = PlayProject(appName, appVersion, appDependencies, mainLang = JAVA).settings()
+  val main = play.Project(appName, appVersion, appDependencies).settings()
 
 }

--- a/samples/jersey/project/build.properties
+++ b/samples/jersey/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.2

--- a/samples/jersey/project/plugins.sbt
+++ b/samples/jersey/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.0.4")
+addSbtPlugin("play" % "sbt-plugin" % "2.1.1")


### PR DESCRIPTION
Here are some updates for playframework-2.1.1.

Aside from the dependency/build updates, I had to fix up PlayAsyncIOWriter.java to compile with playframework-2.1.1. I updated atmosphere-runtime to 1.1.0.RC2 too.

After getting a clean build and install I did a quick smoke test on a Mac via

```
cd samples/chat
mvn play2:run
```

The chat sample works in Firefox and Safari but _doesn't_ work in Chrome -- it simply hangs on connect. I went back and checked and this problem happens in both the original 2.0.4/preforked version and this 2.1.1/forked version.
