### PR TITLE
Make header name lowercase

### DIFF
--- a/module/src/main/java/org/atmosphere/play/AtmosphereUtils.java
+++ b/module/src/main/java/org/atmosphere/play/AtmosphereUtils.java
@@ -130,7 +130,7 @@ public class AtmosphereUtils {
         final Map<String, String> headers = new HashMap<String, String>();
 
         for (Map.Entry<String, String[]> e : request.headers().entrySet()) {
-            headers.put(e.getKey(), e.getValue()[0]);
+            headers.put(e.getKey().toLowerCase(), e.getValue()[0]);
         }
 
         return headers;


### PR DESCRIPTION
To enable getting request headers by AtmosphereRequest.getHeader(String), header names must be lowercased. Now since Play returns header names as upppercase, request.getHeader("user-agent") returns null though request.getHeader("User-Agent") returns not null.
