### PR TITLE
Update to Play 2.2.0

### DIFF
--- a/module/pom.xml
+++ b/module/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>atmosphere-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>play</groupId>
+            <groupId>com.typesafe.play</groupId>
             <artifactId>play_2.10</artifactId>
         </dependency>
         <dependency>

--- a/module/src/main/scala/org/atmosphere/play/Router.scala
+++ b/module/src/main/scala/org/atmosphere/play/Router.scala
@@ -18,7 +18,7 @@ package org.atmosphere.play
 import play.api.mvc.Handler
 import play.core.j._
 import play.mvc.Http.RequestHeader
-import org.apache.commons.lang3.reflect.MethodUtils
+import play.libs.F.Promise
 
 object Router {
 
@@ -50,10 +50,9 @@ object Router {
       JavaWebSocket.ofString(a.webSocket)
     } else {
       new JavaAction {
-        def invocation = a.http
-
-        val controller = c
-        lazy val method = MethodUtils.getMatchingAccessibleMethod(controller, "http")
+        val annotations = new JavaActionAnnotations(c, c.getMethod("http"))
+        val parser = annotations.parser
+        def invocation = Promise.pure(a.http)
       }
     }
 
@@ -77,10 +76,9 @@ object Router {
         Some(JavaWebSocket.ofString(a.webSocket))
       } else {
         Some(new JavaAction {
-          def invocation = a.http
-
-          val controller = c
-          lazy val method = MethodUtils.getMatchingAccessibleMethod(controller, "http")
+          val annotations = new JavaActionAnnotations(c, c.getMethod("http"))
+          val parser = annotations.parser
+          def invocation = Promise.pure(a.http)
         }
         )
       }

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>play</groupId>
+                <groupId>com.typesafe.play</groupId>
                 <artifactId>play_2.10</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/samples/chat/app/org.atmosphere.samples.play/JacksonDecoder.java
+++ b/samples/chat/app/org.atmosphere.samples.play/JacksonDecoder.java
@@ -16,7 +16,7 @@
 package org.atmosphere.samples.play;
 
 import org.atmosphere.config.managed.Decoder;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/samples/chat/app/org.atmosphere.samples.play/JacksonEncoder.java
+++ b/samples/chat/app/org.atmosphere.samples.play/JacksonEncoder.java
@@ -16,7 +16,7 @@
 package org.atmosphere.samples.play;
 
 import org.atmosphere.config.managed.Encoder;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/samples/chat/app/views/index.scala.html
+++ b/samples/chat/app/views/index.scala.html
@@ -21,7 +21,7 @@
                  var logged = false;
                  var socket = atmosphere;
                  var subSocket;
-                 var transport = 'websocket';
+                 var transport = 'long-polling';
 
                  // We are now ready to cut the request
                  var request = { url: document.location.toString() + 'chat',

--- a/samples/chat/project/Build.scala
+++ b/samples/chat/project/Build.scala
@@ -2,7 +2,6 @@ import sbt._
 import Keys._
 import play.Project._
 
-
 object ApplicationBuild extends Build {
 
   def fromEnv(name: String) = System.getenv(name) match {
@@ -19,7 +18,15 @@ object ApplicationBuild extends Build {
     // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
     // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
   )
-
-  val main = play.Project(appName, appVersion, appDependencies).settings()
+  
+  // play2-maven-plugin 1.2.2 can't handle new dist structure of Play 2.2.0
+  // workaround by @maccamlc
+  // https://github.com/nanoko-project/maven-play2-plugin/issues/15#issuecomment-24977753
+  val distFolder = new File("target/dist")
+  distFolder.mkdirs()
+  
+  val main = play.Project(appName, appVersion, appDependencies).settings(
+    target in com.typesafe.sbt.SbtNativePackager.Universal := distFolder
+  )
 
 }

--- a/samples/chat/project/build.properties
+++ b/samples/chat/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.0

--- a/samples/chat/project/plugins.sbt
+++ b/samples/chat/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.1.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version"))

--- a/samples/jersey/project/Build.scala
+++ b/samples/jersey/project/Build.scala
@@ -18,7 +18,15 @@ object ApplicationBuild extends Build {
     // "org.atmosphere" % "atmosphere-runtime" % "1.1.0.SNAPSHOT",
     // "org.atmosphere" % "atmosphere-play" % "1.0.0-SNAPSHOT"
   )
-
-  val main = play.Project(appName, appVersion, appDependencies).settings()
+  
+  // play2-maven-plugin 1.2.2 can't handle new dist structure of Play 2.2.0
+  // workaround by @maccamlc
+  // https://github.com/nanoko-project/maven-play2-plugin/issues/15#issuecomment-24977753
+  val distFolder = new File("target/dist")
+  distFolder.mkdirs()
+  
+  val main = play.Project(appName, appVersion, appDependencies).settings(
+    target in com.typesafe.sbt.SbtNativePackager.Universal := distFolder
+  )
 
 }

--- a/samples/jersey/project/build.properties
+++ b/samples/jersey/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.0

--- a/samples/jersey/project/plugins.sbt
+++ b/samples/jersey/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.1.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version"))


### PR DESCRIPTION
Whenever I execute 'play', I've suffered from JVM heap size though I set maven_opts to use 1024m so that I have to close all browsers and eclipse. It seems that 3Gb memory with Windows 7 32bit is not sufficient to run play. :( So you may confirm this change work correctly again.
