### PR TITLE
Play 2.5 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 before_install: 'mvn -version'
 install: 'mvn clean install'

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ For Play 2.1.x:
      </dependency>
 ```
 
-
-
-
 ## Join the growing community
 
 If you are interested, subscribe to our [mailing list](http://groups.google.com/group/atmosphere-framework) for more info!  We are on irc.freenode.net under #atmosphere-comet

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ Fork the [samples workspace](https://github.com/Atmosphere/atmosphere-samples/tr
 
 Download [Atmosphere Play!](http://search.maven.org/#search%7Cga%7C1%7Catmosphere-play), use Maven or  [sbt](http://ntcoding.blogspot.ca/2013/09/atmosphere-scala-sbt-akka-step-by-step.html)
 
+For Play 2.5.x+:
+
+```xml
+     <dependency>
+         <groupId>org.atmosphere</groupId>
+         <artifactId>atmosphere-play</artifactId>
+         <version>2.3.0</version>
+     </dependency>
+```
+
+For Play 2.4.x+:
+
+```xml
+     <dependency>
+         <groupId>org.atmosphere</groupId>
+         <artifactId>atmosphere-play</artifactId>
+         <version>2.2.0</version>
+     </dependency>
+```
+
 For Play 2.2.x+:
 
 ```xml
@@ -32,6 +52,9 @@ For Play 2.1.x:
          <version>1.0.0</version>
      </dependency>
 ```
+
+
+
 
 ## Join the growing community
 

--- a/module/src/main/java/org/atmosphere/play/AtmosphereController.java
+++ b/module/src/main/java/org/atmosphere/play/AtmosphereController.java
@@ -20,8 +20,8 @@ import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.util.IOUtils;
 import play.mvc.Controller;
+import play.mvc.LegacyWebSocket;
 import play.mvc.Result;
-import play.mvc.WebSocket;
 
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class AtmosphereController extends Controller {
         }
     }
 
-    public WebSocket<String> webSocket() throws Throwable {
+    public LegacyWebSocket<String> webSocket() throws Throwable {
         return new PlayWebSocket(config, request(), convertedSession()).internal();
     }
 

--- a/module/src/main/java/org/atmosphere/play/AtmosphereUtils.java
+++ b/module/src/main/java/org/atmosphere/play/AtmosphereUtils.java
@@ -65,7 +65,7 @@ public class AtmosphereUtils {
             if (request.body().asText() != null) {
                 body = request.body().asText().getBytes("utf-8");
             } else if (request.body().asRaw() != null) {
-                body = request.body().asRaw().asBytes();
+                body = request.body().asBytes().toArray();
             } else if (request.body().asJson() != null) {
                 body = request.body().asJson().asText().getBytes("utf-8");
                 if (body.length == 0) {

--- a/module/src/main/java/org/atmosphere/play/PlayAsyncIOWriter.java
+++ b/module/src/main/java/org/atmosphere/play/PlayAsyncIOWriter.java
@@ -62,12 +62,7 @@ public class PlayAsyncIOWriter extends AtmosphereInterceptorWriter implements Pl
                 try {
                     final AtmosphereRequest r = AtmosphereUtils.request(request, additionalAttributes);
                     if (transport != null && transport.length > 0 && !transport[0].equalsIgnoreCase(HeaderConfig.POLLING_TRANSPORT)) {
-                        out.onDisconnected(new F.Callback0() {
-                            @Override
-                            public void invoke() throws Throwable {
-                                _close(r);
-                            }
-                        });
+                        out.onDisconnected(() -> _close(r));
                     }
 
                     AtmosphereResponse res = new AtmosphereResponseImpl.Builder()

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>com.typesafe.play</groupId>
                 <artifactId>play_2.11</artifactId>
-                <version>2.4.6</version>
+                <version>2.5.4</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -188,7 +188,7 @@
                 <version>2.7</version>
                 <configuration>
                     <aggregate>true</aggregate>
-                    <source>1.6</source>
+                    <source>1.8</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>


### PR DESCRIPTION
Changes:
* Fixed all compile errors
* Migrated WebSocked to LegacyWebSocket
* Replace Promis with CompletableFuture
* Set java version to 1.8

How to use it in a play project (same as for 2.4):
* Set property play.http.requestHandler in application.conf to play.http.requestHandler = "org.atmosphere.play.AtmosphereHttpRequestHandler"

I tested my changes only with a play-java 2.5.4 application.
Would be cool if you can merge/release it fast. :)

Feedback is welcome. :)

This pull request should also fix #37 
